### PR TITLE
Correctly handle datapacks with multiple orgunit UIDs

### DIFF
--- a/server.R
+++ b/server.R
@@ -228,8 +228,7 @@ shinyServer(function(input, output, session) {
       
       if (!inherits(d,"error") & !is.null(d)) {
         
-        #We do not have a great way of dealing with datapacks with multiple country ids...
-        d$info$country_uids<-substr(paste0(d$info$country_uids,sep="",collapse="_"),0,25)
+
         d$info$sane_name<-paste0(stringr::str_extract_all(d$info$datapack_name,"[A-Za-z0-9_]",
                                                           simplify = TRUE),sep="",collapse="")
         #Keep this until we can change the schema

--- a/utils.R
+++ b/utils.R
@@ -191,6 +191,8 @@ getCountryNameFromUID<-function(uid) {
 
 archiveDataPacktoS3<-function(d,datapath,config) {
   
+  d$info$country_uids<-substr(paste0(d$info$country_uids,sep="",collapse="_"),0,25)
+  
   #Write an archived copy of the file
   s3<-paws::s3()
   tags<-c("tool","country_uids","cop_year","has_error","sane_name")
@@ -229,6 +231,9 @@ archiveDataPackErrorUI <- function(r) {
 }
 
 saveTimeStampLogToS3<-function(d) {
+  
+  d$info$country_uids<-substr(paste0(d$info$country_uids,sep="",collapse="_"),0,25)
+  
   #Write an archived copy of the file
   s3<-paws::s3()
   tags<-c("tool","country_uids","cop_year","has_error","sane_name")
@@ -329,6 +334,9 @@ prepareFlatMERExport<-function(d) {
 }
 
 sendMERDataToPAW<-function(d,config) {
+  
+  d$info$country_uids<-substr(paste0(d$info$country_uids,sep="",collapse="_"),0,25)
+  
   #Write the flatpacked output
   tmp <- tempfile()
   mer_data<-d$data$analytics
@@ -378,7 +386,7 @@ sendMERDataToPAW<-function(d,config) {
 
 sendValidationSummary<-function(vr,config) {
   
-  
+  vr$info$country_uids<-substr(paste0(vr$info$country_uids,sep="",collapse="_"),0,25)
   validation_summary<-validationSummary(vr)
   
   tmp <- tempfile()


### PR DESCRIPTION
Issues: 
1) The datimvalidation package has been created to validated certain parts of the data payload like mechanisms and orgunit associations, based on a particular users assigned organisation unit. 
2) It is possible that datapacks may have multiple countries in a single datapack, or potentially even arbitrary orgunits.
3) We need a single name for a data pack which is short enough to be used for an S3 file name. 

Previously, the app was mangling the `d$info$country_uids` list to a single character string, which in turn caused problems when regenerating datapacks which contained multiple country uids. 

This PR will move this mangling into functions and leave the original object untouched, so that the original list can be used when regenerating PSNUxIM tabs. 

Datim validation will continue to use the UID of the user, which in theory, could present problems of users which do not have access in DATIM to the orgunits contained in the datapack. This seems like a real edge case however, so for now, this will be a potential known limitation. 
 

FYI @sam-bao @jacksonsj 